### PR TITLE
Fix display params memcpy sizeof issue causing mirrorY to be lost

### DIFF
--- a/firmware/drivers/oepl_display_driver_GDEW0583Z83.c
+++ b/firmware/drivers/oepl_display_driver_GDEW0583Z83.c
@@ -69,7 +69,7 @@ static void display_init(const oepl_display_parameters_t* display_params)
   }
 
   // Make local copy since we'll be using most of these
-  memcpy(params, display_params, sizeof(*display_params));
+  memcpy(params, display_params, sizeof(oepl_display_parameters_t));
 }
 
 static void display_draw(void)

--- a/firmware/drivers/oepl_display_driver_dualssd.c
+++ b/firmware/drivers/oepl_display_driver_dualssd.c
@@ -107,7 +107,7 @@ static void display_init(const oepl_display_parameters_t* display_params)
   }
 
   // Make local copy since we'll be using most of these
-  memcpy(params, display_params, sizeof(*display_params));
+  memcpy(params, display_params, sizeof(oepl_display_parameters_t));
 }
 
 static void display_draw(void)

--- a/firmware/drivers/oepl_display_driver_uc8159.c
+++ b/firmware/drivers/oepl_display_driver_uc8159.c
@@ -118,7 +118,7 @@ static void display_init(const oepl_display_parameters_t* display_params)
   }
 
   // Make local copy since we'll be using most of these
-  memcpy(params, display_params, sizeof(*display_params));
+  memcpy(params, display_params, sizeof(oepl_display_parameters_t));
 
   // Todo: Add pin definition for UC8159's onboard flash CS line
   oepl_hw_crash(DBG_DISPLAY, false, "UC8159 is not yet supported\n");

--- a/firmware/drivers/oepl_display_driver_uc8179.c
+++ b/firmware/drivers/oepl_display_driver_uc8179.c
@@ -105,7 +105,7 @@ static void display_init(const oepl_display_parameters_t* display_params)
   }
 
   // Make local copy since we'll be using most of these
-  memcpy(params, display_params, sizeof(*display_params));
+  memcpy(params, display_params, sizeof(oepl_display_parameters_t));
 }
 
 static void display_draw(void)

--- a/firmware/drivers/oepl_display_driver_ucvar029.c
+++ b/firmware/drivers/oepl_display_driver_ucvar029.c
@@ -80,7 +80,7 @@ static void display_init(const oepl_display_parameters_t* display_params)
   }
 
   // Make local copy since we'll be using most of these
-  memcpy(params, display_params, sizeof(*display_params));
+  memcpy(params, display_params, sizeof(oepl_display_parameters_t));
 }
 
 static void display_draw(void)

--- a/firmware/drivers/oepl_display_driver_ucvar043.c
+++ b/firmware/drivers/oepl_display_driver_ucvar043.c
@@ -80,7 +80,7 @@ static void display_init(const oepl_display_parameters_t* display_params)
   }
 
   // Make local copy since we'll be using most of these
-  memcpy(params, display_params, sizeof(*display_params));
+  memcpy(params, display_params, sizeof(oepl_display_parameters_t));
 }
 
 static void display_draw(void)

--- a/firmware/drivers/oepl_display_driver_unissd.c
+++ b/firmware/drivers/oepl_display_driver_unissd.c
@@ -104,7 +104,7 @@ static void display_init(const oepl_display_parameters_t* display_params)
   }
 
   // Make local copy since we'll be using most of these
-  memcpy(params, display_params, sizeof(*display_params));
+  memcpy(params, display_params, sizeof(oepl_display_parameters_t));
 }
 
 static void display_draw(void)


### PR DESCRIPTION
Changed memcpy to use sizeof the display params type