### PR TITLE
Draw mirrored displays unmirrored

### DIFF
--- a/firmware/drivers/oepl_display_driver_common.c
+++ b/firmware/drivers/oepl_display_driver_common.c
@@ -343,11 +343,9 @@ void oepl_display_scan_frame_multi(uint8_t* xbuf, size_t bufsize, size_t xstart,
 
   for(size_t line = ystart; line < ystart + ylines; line++) {
     memset(xbuf, 0, bufsize);
-    if(mirrorY) {
-      C_renderDrawLine(xbuf, ystart + ylines - 1 - (line - ystart), color);
-    } else {
-      C_renderDrawLine(xbuf, line, color);
-    }
+    
+    C_renderDrawLine(xbuf, line, color);
+
     if(mirrorX) {
       for(size_t i = 0; i < xbytes; i++) {
         swapbuf[xbytes - 1 - i] = SL_RBIT8(xbuf[xstart + i]);


### PR DESCRIPTION
Draw mirrored displays unmirrored to support display controller increment/window control to mirror the image.

We were instructing the display controller to draw backwards in the unissd driver.

Later when feeding the image to the driver from the image buffer, we were feeding the image backwards as well.

With both methods of mirroring employed, the resulting image was still inverted.