### PR TITLE
Add support for the EL016F6W4A M3 1.6" BWRY variant.

### DIFF
--- a/firmware/oepl_compression.cpp
+++ b/firmware/oepl_compression.cpp
@@ -91,6 +91,8 @@ void decompress::setupContext() {
     this->ctx->source_limit = this->compBuffer + ZLIB_CACHE_SIZE;
     compressedPos = 0;
     decompressedPos = 0;
+    cacheStart = 0;
+    cacheLen = 0;
 }
 
 decompress::~decompress() {

--- a/firmware/oepl_display.c
+++ b/firmware/oepl_display.c
@@ -401,6 +401,7 @@ static void add_rendered_content_splash(void)
     case SOLUM_M3_BWR_16:
     case SOLUM_M3_BWRY_16:
     case SOLUM_M3_BWRY_16_HIGHRES:
+    case SOLUM_M3_BWRY_16_HIGHRES_ROTATED:
       C_epdSetFont(&FreeSans9pt7b);
       C_epdPrintf(2, 2, COLOR_BLACK, ROTATE_0, "OpenEPaperLink");
       if (hwid == SOLUM_M3_PEGHOOK_BWR_13) {
@@ -408,7 +409,7 @@ static void add_rendered_content_splash(void)
       } else {
         C_epdPrintf(10, 38, COLOR_RED, ROTATE_0, "Newton M3 1.6\"");
       }
-      if (hwid == SOLUM_M3_BWRY_16 || hwid == SOLUM_M3_BWRY_16_HIGHRES) {
+      if (hwid == SOLUM_M3_BWRY_16 || hwid == SOLUM_M3_BWRY_16_HIGHRES || hwid == SOLUM_M3_BWRY_16_HIGHRES_ROTATED) {
         C_epdPrintf(5, yres - 60, COLOR_YELLOW, ROTATE_0, "BWRY");
       }
       C_epdPrintf(5, yres - 40, COLOR_BLACK, ROTATE_0, "FW: %04X-%s", fw, suffix);

--- a/firmware/oepl_efr32_hwtypes.c
+++ b/firmware/oepl_efr32_hwtypes.c
@@ -383,6 +383,8 @@ uint8_t oepl_efr32xg22_get_oepl_hwid(void)
         return SOLUM_M3_BWRY_16;
       case STYPE_SIZE_16_BWRY_HIGHRES:
         return SOLUM_M3_BWRY_16_HIGHRES;
+      case STYPE_SIZE_16_BWRY_HIGHRES_ROTATED:
+        return SOLUM_M3_BWRY_16_HIGHRES_ROTATED;
       case STYPE_SIZE_22_BWRY:
         return SOLUM_M3_BWRY_22;
       case STYPE_SIZE_24_BWRY:
@@ -611,6 +613,10 @@ bool oepl_efr32xg22_get_displayparams(oepl_efr32xg22_displayparams_t* displaypar
       case STYPE_SIZE_16_BWRY_HIGHRES:
         displayparams->swapXY = false;
         displayparams->mirrorY = false;
+        break;
+      case STYPE_SIZE_16_BWRY_HIGHRES_ROTATED:
+        displayparams->swapXY = true;
+        displayparams->mirrorY = true;
         break;
       case STYPE_SIZE_22_BWRY:
         displayparams->swapXY = true;


### PR DESCRIPTION
JSON tag file 91.json and Shared_OEPL_Definitions have been committed.
zlib compression is not enabled in 91.json for now.

The update freeze hasn't reoccurred  after 48+ hrs.  I'll keep an eye on it, but I doubt it's related to these changes.
