### PR TITLE
Add SES-imagotag EL042TS1 hardware variant (4.2" BWRY, 256 kB FG22, no external flash)

### DIFF
--- a/PORT_PLAN.md
+++ b/PORT_PLAN.md
@@ -1,0 +1,222 @@
+# SES-imagotag EL042TS1 port plan
+
+Branch: `sesimagotag-el042ts1` (off `main`).
+
+## Goal
+
+Add a new hardware variant to `Tag_FW_EFR32xG22` so that an OEPL
+firmware build runs on the SES-imagotag EL042TS1 4.2" BWY tag
+(EFR32FG22 MCU, JD79653-style controller panel).
+
+The driver, pin map, palette, and all quirks were characterized in
+`~/personal_repos/epaper_tag/EL042TS1_DRIVER.md` — read that first.
+
+## Concrete edits required (all in `firmware/`)
+
+### 1. `oepl_efr32_hwtypes.h`
+
+- Reserve a new hwtype ID (suggestion: `OEPL_EFR32XG22_HWTYPE_SESIMAGOTAG_EL042TS1 = 0x08`) in the enum and `#define` list.
+  Keep in sync with the bootloader as the comment demands.
+- Add a new `oepl_efr32xg22_displaytype_t` enum value: `EPD_SESIMAGOTAG_EL042TS1`. (Alternative: reuse `EPD_SOLUM_AUTODETECT` but override via hwtype; adding a new type is cleaner.)
+
+### 2. `oepl_efr32_hwtypes.c`
+
+Add new static configs:
+
+```c
+static const oepl_efr32xg22_flashconfig_t flashconfig_sesimagotag_el042ts1 = {
+  .usart = USART0,
+  .MOSI = GPIO_UNUSED,
+  .MISO = GPIO_UNUSED,
+  .SCK  = GPIO_UNUSED,
+  .nCS  = GPIO_UNUSED,
+  .EN   = GPIO_UNUSED,
+};
+// NOTE: external flash pins are not yet identified on this board.
+// Build with internal-flash-only first; revisit if we need extra image
+// storage. See bench TODO below.
+
+static const oepl_efr32xg22_displayconfig_t displayconfig_sesimagotag_el042ts1 = {
+  .usart       = USART0,                // or whichever USART serves PC00..PC04
+  .usart_clock = cmuClock_USART0,
+  .MOSI  = {.port = gpioPortC, .pin = 0},
+  .MISO  = GPIO_UNUSED,
+  .SCK   = {.port = gpioPortC, .pin = 1},
+  .nCS   = {.port = gpioPortC, .pin = 2},
+  .nCS2  = GPIO_UNUSED,
+  .DC    = {.port = gpioPortC, .pin = 3},
+  .BUSY  = {.port = gpioPortA, .pin = 7},
+  .nRST  = {.port = gpioPortC, .pin = 4},
+  // PC06 is the BS (SPI mode select) pin — MUST BE LOW.
+  // Re-using the `enable` field with idle_state = 0 achieves this:
+  // OEPL will drive it LOW during display activity.
+  // CAVEAT: check that the driver doesn't toggle it off-display; it
+  // must stay LOW for the chip to stay in 4-wire SPI mode.
+  .enable = {.port = gpioPortC, .pin = 6, .idle_state = 0},
+  .type   = EPD_SESIMAGOTAG_EL042TS1,
+};
+
+static const oepl_efr32xg22_pinconfig_t pinconfig_sesimagotag_el042ts1 = {
+  .gpio = GPIO_UNUSED,
+  .nfc_fd = GPIO_UNUSED,       // NFC not yet probed on this board
+  .nfc_fd_em4wuval = 0,
+  .button1 = GPIO_UNUSED,       // button not yet identified
+  .button1_em4wuval = 0,
+  .button2 = GPIO_UNUSED,
+  .button2_em4wuval = 0,
+};
+
+static const oepl_efr32xg22_ledconfig_t ledconfig_sesimagotag_el042ts1 = {
+  .red    = {.port = gpioPortB, .pin = 2},
+  .green  = {.port = gpioPortB, .pin = 1},
+  .blue   = {.port = gpioPortB, .pin = 3},
+  .white  = {.port = gpioPortB, .pin = 4},
+};
+
+static const oepl_efr32xg22_debugconfig_t debugconfig_sesimagotag_el042ts1 = {
+  .type = DBG_SWO,              // SWO until we identify a UART pin
+  .output = { .euart = { .tx = GPIO_UNUSED, .rx = GPIO_UNUSED, ... } },
+};
+
+static const oepl_efr32xg22_tagconfig_t tagconfig_sesimagotag_el042ts1 = {
+  .hwtype = SESIMAGOTAG_EL042TS1,
+  .oepl_hwid = SOLUM_M3_BWRY_42,   // tells AP "I'm a 4.2" BWRY"
+  .flash   = &flashconfig_sesimagotag_el042ts1,
+  .display = &displayconfig_sesimagotag_el042ts1,
+  .gpio    = &pinconfig_sesimagotag_el042ts1,
+  .led     = &ledconfig_sesimagotag_el042ts1,
+  .nfc     = NULL,
+  .debug   = &debugconfig_sesimagotag_el042ts1,
+};
+```
+
+Then register in `tagdb[]`:
+
+```c
+static const oepl_efr32xg22_tagconfig_t* tagdb[] = {
+  &tagconfig_brd4402b_memlcd,
+  &tagconfig_brd4402b_epd,
+  &tagconfig_solum,
+  &tagconfig_modchip_hd150,
+  &tagconfig_sesimagotag_el042ts1,   // NEW
+};
+```
+
+### 3. `get_displayparams` — new branch for our display type
+
+In `oepl_efr32xg22_get_displayparams`, add a branch for
+`display->type == EPD_SESIMAGOTAG_EL042TS1` that hardcodes:
+
+```c
+displayparams->xres = 400;
+displayparams->yres = 300;
+displayparams->xres_working = 400;
+displayparams->yres_working = 300;
+displayparams->have_thirdcolor  = true;
+displayparams->have_fourthcolor = false;   // BWY, not BWRY
+displayparams->ctrl = CTRL_JD;
+displayparams->xoffset = 0;
+displayparams->yoffset = 0;
+displayparams->mirrorX = false;
+displayparams->mirrorY = false;
+displayparams->swapXY = false;
+```
+
+We cannot reuse `EPD_SOLUM_AUTODETECT` because our tag's userdata
+layout does not match Solum's (offset 0x09 reads 0x30 on ours, not
+the expected JD driver ID 0x2B — the SES-imagotag FCC-ID generation
+pre-merger had different userdata formats).
+
+### 4. `get_oepl_hwid` — return the hardcoded `SOLUM_M3_BWRY_42`
+
+The existing `else` branch (`return tagcfg->oepl_hwid;`) already
+handles this correctly since we set `oepl_hwid = SOLUM_M3_BWRY_42`
+in our tagconfig. No change needed here, as long as `hwtype !=
+SOLUM_AUTODETECT` for us (which is the case).
+
+### 5. Pull in DanSchoppe's 400×300 JD init block
+
+`firmware/drivers/oepl_display_driver_jd.c` — add the 400×300 init
+from https://github.com/DanSchoppe/Tag_FW_EFR32xG22/pull/1 into the
+`display_reinit` switch. Verbatim, it's:
+
+```c
+} else if(params->x_res_effective == 400 && params->y_res_effective == 300) {
+    // From Waveshare 400x300 sample
+    EMIT_INSTRUCTION_STATIC_DATA(0x4D, {0x78});
+    EMIT_INSTRUCTION_STATIC_DATA(0x00, {0x0F,0x29});
+    EMIT_INSTRUCTION_STATIC_DATA(0x06, {0x0D,0x12,0x24,0x25,0x12,0x29,0x10});
+    EMIT_INSTRUCTION_STATIC_DATA(0x30, {0x08});
+    EMIT_INSTRUCTION_STATIC_DATA(0x50, {0x37});
+    EMIT_INSTRUCTION_VAR_DATA(EPD_CMD_RESOLUTION_SETTING, {...});
+    EMIT_INSTRUCTION_STATIC_DATA(0xAE, {0xCF});
+    EMIT_INSTRUCTION_STATIC_DATA(0xB0, {0x13});
+    EMIT_INSTRUCTION_STATIC_DATA(0xBD, {0x07});
+    EMIT_INSTRUCTION_STATIC_DATA(0xBE, {0xFE});
+    EMIT_INSTRUCTION_STATIC_DATA(0xE9, {0x01});
+    EMIT_INSTRUCTION_NO_DATA(0x04);
+    sl_udelay_wait(500);
+    oepl_display_driver_wait(2000);
+}
+```
+
+### 6. Bootloader
+
+The bootloader folder has its own readme. It needs a matching
+hwtype value, otherwise `oepl_efr32xg22_get_config()` won't find
+our tagconfig at runtime. Walk through `bootloader/` to find where
+`btl_id` is set. Likely a Makefile define or a constants header.
+
+## Build
+
+Use the Dockerfile so we don't need Simplicity Studio locally:
+
+```
+docker build -t silabs-builder -f Dockerfile .
+docker run --rm -it --user builder -v $(pwd):/build -v ~/.gitconfig:/home/builder/.gitconfig silabs-builder
+./build_all.sh   # inside the container
+```
+
+Expected output: new `*.s37` images in `full_binaries/` including one
+matching our hwtype.
+
+## Flash
+
+Same J-Link tooling we used in the custom firmware:
+- For ad-hoc/erase/probe: `-device Cortex-M33`.
+- For flashing (loadfile): `-device EFR32BG22C224F512IM40`
+  (the BG22 profile that worked in the original project).
+
+## Bench TODOs
+
+Before a first end-to-end test:
+
+1. **Physically trace ONE display FPC pin to the MCU** to confirm the
+   logical pin map. The reset-pulse sweep that identified RST=PC04
+   was very thorough, but a multimeter continuity check is a cheap
+   belt-and-suspenders move before committing a hardware config.
+2. **Find the external flash pins**, if there is external flash. If
+   we build with `flashconfig = GPIO_UNUSED` and OEPL tries to use
+   the flash we'll get runtime errors. Visible flash IC on the board?
+3. **Identify a debug UART pad** (OEPL wants VCOM for prints). If
+   none routed, stick with SWO via the J-Link.
+4. **Button pin** — the board probably has a physical button; we
+   haven't identified which MCU pin it's on.
+
+## Upstream PR path
+
+Once we have a clean working build:
+1. Squash the commits into a single "Add SES-imagotag EL042TS1
+   hardware variant" PR against `Tag_FW_EFR32xG22:main`.
+2. Reference issue #15 and link our findings.
+3. Offer our driver reference (`EL042TS1_DRIVER.md`) as documentation
+   under `documentation/`.
+
+## State check
+
+- Fork created:  https://github.com/nuno407/Tag_FW_EFR32xG22
+- Local clone:   /Users/nuno/personal_repos/Tag_FW_EFR32xG22
+- Branch:        sesimagotag-el042ts1
+- Submodules:    initialized (via https, not git@)
+- Nothing yet committed on the branch. Start of next session picks up
+  here.

--- a/bootloader/generate_variants.py
+++ b/bootloader/generate_variants.py
@@ -45,6 +45,18 @@ variant_map = [
         "variant_idbyte": "0x07"
     },
     {
+        # SES-imagotag EL042TS1 (4.2" BWY). No external flash identified
+        # on this tag; for first bring-up we reuse the Solum bootloader
+        # base, which targets xG22 and configures port C for SPI flash.
+        # SFDP detection will fail (no flash present) and the bootloader
+        # will boot the app. The app's display driver pulses RST in init,
+        # clearing any garbage the bootloader's SPI traffic left on the
+        # panel bus. Revisit with a dedicated BTL_TYPE if runtime issues.
+        "variant_name": "SESIMAGOTAG_EL042TS1",
+        "variant_base": "Solum_SPIF_BTL.s37",
+        "variant_idbyte": "0x08"
+    },
+    {
         "variant_name": "DEVELOPMENT_0",
         "variant_base": "Development_SPIF_BTL.s37",
         "variant_idbyte": "0xF0",

--- a/firmware/EFR32xG22_OEPL.slcp
+++ b/firmware/EFR32xG22_OEPL.slcp
@@ -148,7 +148,9 @@ template_contribution:
 - {name: memory_ram_start, priority: 0, value: 536870912}
 - {name: memory_ram_size, priority: 0, value: 32768}
 - {name: memory_flash_start, priority: 0, value: 24576}
-- {name: memory_flash_size, priority: 0, value: 335872}
+# 256 kB part (SES-imagotag EL042TS1): app + NVM3 end at 0x38000, the
+# remaining 32 kB up to 0x40000 is the internal image storage slot.
+- {name: memory_flash_size, priority: 0, value: 204800}
 requires:
 - {name: a_radio_config}
 - condition: [kernel]
@@ -229,7 +231,7 @@ configuration:
 - {name: SL_RAIL_UTIL_PROTOCOL_IEEE802154_2P4GHZ_ACCEPT_ACK_FRAME_ENABLE, value: '0'}
 - {name: SL_RAIL_UTIL_PTI_MODE, value: 'RAIL_PTI_MODE_DISABLED'}
 - {name: SL_IOSTREAM_EUSART_EUART_DEBUG_RESTRICT_ENERGY_MODE_TO_ALLOW_RECEPTION, value: '0'}
-- {name: SL_APPLICATION_VERSION, value: '43'}
+- {name: SL_APPLICATION_VERSION, value: '11016'}
 config_file:
   - path: sl_iostream_eusart_euart_debug_config.h
     override:

--- a/firmware/drivers/oepl_display_driver_jd.c
+++ b/firmware/drivers/oepl_display_driver_jd.c
@@ -277,8 +277,14 @@ static void display_reinit(void)
        tagcfg->display->type == EPD_SESIMAGOTAG_EL042TS1);
 
     if (is_sesimagotag_el042ts1) {
-      // SES-imagotag EL042TS1 (4.2" BWRY, JD79653-family). Reverse-
-      // engineered on-bench; values from EL042TS1_DRIVER.md.
+      // SES-imagotag EL042TS1 (4.2" BWRY, JD79653-family).
+      //
+      // Register values are the M3 BWRY 4.2" capture (PR#16 set, below in
+      // the else-branch): with these the panel develops red and yellow as
+      // distinct colours. The earlier bench-derived set (PWR {0x03, 0x00,
+      // 0x2B, 0x2B, 0x03}, BTST {0x17 x3}, PSR {0x3F, 0x09}, CDI 0x97)
+      // drove a mode where pixel codes 0b10 and 0b11 both rendered
+      // yellow — see EL042TS1_DRIVER.md.
       //
       // CRITICAL SEQUENCING: this panel requires PON BEFORE DTM1. The
       // standard OEPL flow (DTM1 in display_draw, PON in
@@ -287,11 +293,29 @@ static void display_reinit(void)
       // until PON has turned on the booster rails. We therefore issue
       // PON at the end of display_reinit here, and display_refresh_and_wait
       // skips its own PON for this displaytype.
-      EMIT_INSTRUCTION_STATIC_DATA(0x01, {0x03, 0x00, 0x2B, 0x2B, 0x03});   // PWR
-      EMIT_INSTRUCTION_STATIC_DATA(0x06, {0x17, 0x17, 0x17});                 // BTST
-      EMIT_INSTRUCTION_STATIC_DATA(0x00, {0x3F, 0x09});                       // PSR (2 bytes)
+      EMIT_INSTRUCTION_STATIC_DATA(0x00, {0x0F, 0x29});                       // PSR
+      EMIT_INSTRUCTION_STATIC_DATA(0x01, {0x07, 0x00, 0x26, 0x78, 0x24, 0x26}); // PWR
+      EMIT_INSTRUCTION_STATIC_DATA(0x03, {0x10, 0x54, 0x44});                 // PFS
+      EMIT_INSTRUCTION_STATIC_DATA(0x06, {0xC0, 0xC0, 0xC0});                 // BTST
       EMIT_INSTRUCTION_VAR_DATA(EPD_CMD_RESOLUTION_SETTING, {params->x_res_effective >> 8, params->x_res_effective & 0xFF, params->y_res_effective >> 8, params->y_res_effective & 0xFF});
-      EMIT_INSTRUCTION_STATIC_DATA(0x50, {0x97});                             // CDI
+      EMIT_INSTRUCTION_STATIC_DATA(0x30, {0x02});                             // PLL
+      // CDI[7:6] select the border colour using pixel codes (00=black,
+      // 01=white, 10=yellow, 11=red). The Solum capture uses 0x17 (black
+      // border); we prefer white.
+      EMIT_INSTRUCTION_STATIC_DATA(0x50, {0x57});                             // CDI
+      EMIT_INSTRUCTION_STATIC_DATA(0xFF, {0xA5});                             // vendor unlock
+      EMIT_INSTRUCTION_STATIC_DATA(0xEF, {0x01, 0x32, 0x08, 0x32, 0x0E, 0x4B, 0x19, 0x4B});
+      EMIT_INSTRUCTION_STATIC_DATA(0xDB, {0x00});
+      EMIT_INSTRUCTION_STATIC_DATA(0xF9, {0x01});
+      EMIT_INSTRUCTION_STATIC_DATA(0xCF, {0x00});
+      EMIT_INSTRUCTION_STATIC_DATA(0xDF, {0x3C});
+      EMIT_INSTRUCTION_STATIC_DATA(0xFD, {0x01});
+      EMIT_INSTRUCTION_STATIC_DATA(0xE8, {0x00});
+      EMIT_INSTRUCTION_STATIC_DATA(0xDC, {0x00});
+      EMIT_INSTRUCTION_STATIC_DATA(0xDD, {0x01});
+      EMIT_INSTRUCTION_STATIC_DATA(0xDE, {0x01});
+      EMIT_INSTRUCTION_STATIC_DATA(0xFF, {0xE3});                             // vendor lock
+      EMIT_INSTRUCTION_STATIC_DATA(0xE9, {0x01});
       EMIT_INSTRUCTION_NO_DATA(0x04);                                          // PON (before DTM1)
       sl_udelay_wait(500);
       oepl_display_driver_wait_busy(4000, true);

--- a/firmware/drivers/oepl_display_driver_jd.c
+++ b/firmware/drivers/oepl_display_driver_jd.c
@@ -9,6 +9,9 @@
 // For debugprint
 #include "oepl_hw_abstraction.h"
 
+// For per-tag init variants (see the 400x300 branch in display_reinit).
+#include "oepl_efr32_hwtypes.h"
+
 #include <string.h>
 #include <stdlib.h>
 
@@ -180,11 +183,20 @@ static void display_sleep(void)
 
 static void display_refresh_and_wait(void)
 {
-  if((params->x_res_effective == 168 && params->y_res_effective == 384) ||
-     (params->x_res_effective == 184 && params->y_res_effective == 360) ||
-     (params->x_res_effective == 200 && params->y_res_effective == 200) ||
-     (params->x_res_effective == 160 && params->y_res_effective == 296) ||
-     (params->x_res_effective == 400 && params->y_res_effective == 300)) {
+  // SES-imagotag EL042TS1 does its PON in display_reinit (before DTM1),
+  // so skip the PON here for that displaytype to avoid a second power-
+  // cycle that would reset the frame RAM we just wrote.
+  const oepl_efr32xg22_tagconfig_t* tagcfg_pon = oepl_efr32xg22_get_config();
+  bool skip_pon_here =
+    (tagcfg_pon != NULL && tagcfg_pon->display != NULL &&
+     tagcfg_pon->display->type == EPD_SESIMAGOTAG_EL042TS1);
+
+  if(!skip_pon_here &&
+     ((params->x_res_effective == 168 && params->y_res_effective == 384) ||
+      (params->x_res_effective == 184 && params->y_res_effective == 360) ||
+      (params->x_res_effective == 200 && params->y_res_effective == 200) ||
+      (params->x_res_effective == 160 && params->y_res_effective == 296) ||
+      (params->x_res_effective == 400 && params->y_res_effective == 300))) {
     oepl_display_driver_wait(10);
     DPRINTF("Turn on EPD power rails\n");
     EMIT_INSTRUCTION_STATIC_DATA(0x04, {0x00});
@@ -259,6 +271,31 @@ static void display_reinit(void)
     EMIT_INSTRUCTION_STATIC_DATA(0x30, {0x08});
     oepl_display_driver_wait(300);
   } else if(params->x_res_effective == 400 && params->y_res_effective == 300) {
+    const oepl_efr32xg22_tagconfig_t* tagcfg = oepl_efr32xg22_get_config();
+    bool is_sesimagotag_el042ts1 =
+      (tagcfg != NULL && tagcfg->display != NULL &&
+       tagcfg->display->type == EPD_SESIMAGOTAG_EL042TS1);
+
+    if (is_sesimagotag_el042ts1) {
+      // SES-imagotag EL042TS1 (4.2" BWRY, JD79653-family). Reverse-
+      // engineered on-bench; values from EL042TS1_DRIVER.md.
+      //
+      // CRITICAL SEQUENCING: this panel requires PON BEFORE DTM1. The
+      // standard OEPL flow (DTM1 in display_draw, PON in
+      // display_refresh_and_wait) produces banded noise on this panel,
+      // because the chip's frame RAM isn't ready to accept DTM1 writes
+      // until PON has turned on the booster rails. We therefore issue
+      // PON at the end of display_reinit here, and display_refresh_and_wait
+      // skips its own PON for this displaytype.
+      EMIT_INSTRUCTION_STATIC_DATA(0x01, {0x03, 0x00, 0x2B, 0x2B, 0x03});   // PWR
+      EMIT_INSTRUCTION_STATIC_DATA(0x06, {0x17, 0x17, 0x17});                 // BTST
+      EMIT_INSTRUCTION_STATIC_DATA(0x00, {0x3F, 0x09});                       // PSR (2 bytes)
+      EMIT_INSTRUCTION_VAR_DATA(EPD_CMD_RESOLUTION_SETTING, {params->x_res_effective >> 8, params->x_res_effective & 0xFF, params->y_res_effective >> 8, params->y_res_effective & 0xFF});
+      EMIT_INSTRUCTION_STATIC_DATA(0x50, {0x97});                             // CDI
+      EMIT_INSTRUCTION_NO_DATA(0x04);                                          // PON (before DTM1)
+      sl_udelay_wait(500);
+      oepl_display_driver_wait_busy(4000, true);
+    } else {
     // From captured waveform https://github.com/OpenEPaperLink/Tag_FW_EFR32xG22/pull/16
     EMIT_INSTRUCTION_STATIC_DATA(0x00, {0x0F, 0x29});
     EMIT_INSTRUCTION_STATIC_DATA(0x01, {0x07, 0x00, 0x26, 0x78, 0x24, 0x26});
@@ -280,6 +317,7 @@ static void display_reinit(void)
     EMIT_INSTRUCTION_STATIC_DATA(0xDE, {0x01});
     EMIT_INSTRUCTION_STATIC_DATA(0xFF, {0xE3});
     EMIT_INSTRUCTION_STATIC_DATA(0xE9, {0x01});
+    }
   } else if(params->x_res_effective == 800 && params->y_res_effective == 480) {
     // From Waveshare 800x480 sample
     //   https://github.com/waveshareteam/e-Paper/blob/master/E-paper_Separate_Program/7in5_e-Paper_H/ESP32/EPD_7in5h.cpp

--- a/firmware/fonts/FreeSansBold24pt7b.c
+++ b/firmware/fonts/FreeSansBold24pt7b.c
@@ -1,4 +1,9 @@
 #include "fonts.h"
 
+// On small-flash builds fonts.h aliases FreeSansBold24pt7b to the 18 pt
+// font, so compiling the 24 pt glyph data here would produce a duplicate
+// definition of FreeSansBold18pt7b.
+#if !defined(OEPL_SMALL_FLASH)
 #define PROGMEM
 #include "../common/fonts/FreeSansBold24pt7b.h"
+#endif

--- a/firmware/fonts/fonts.h
+++ b/firmware/fonts/fonts.h
@@ -1,5 +1,12 @@
 #include "../oepl_drawing_capi.h" // Definition of GFXfont
+#include "../oepl_build_flags.h"
 
 extern const GFXfont FreeSans9pt7b;
 extern const GFXfont FreeSansBold18pt7b;
+#if defined(OEPL_SMALL_FLASH)
+// Only layouts for >= 4.3" panels use the 24 pt font. Alias it to the
+// 18 pt font so the ~9 kB of glyph data can be garbage-collected.
+#define FreeSansBold24pt7b FreeSansBold18pt7b
+#else
 extern const GFXfont FreeSansBold24pt7b;
+#endif

--- a/firmware/oepl_build_flags.h
+++ b/firmware/oepl_build_flags.h
@@ -1,0 +1,21 @@
+#ifndef OEPL_BUILD_FLAGS_H
+#define OEPL_BUILD_FLAGS_H
+
+// OEPL_SMALL_FLASH: build for xG22 parts with only 256 kB of main flash
+// (e.g. the EFR32FG22 on SES-imagotag EL042TS1 tags). The standard build
+// assumes a 352 kB part and external SPI flash for image storage; on a
+// 256 kB part with no external flash, the application must shrink to
+// leave room for NVM3 and one internal image slot:
+//
+//   0x00000 - 0x06000  bootloader            ( 24 kB)
+//   0x06000 - 0x32000  application           (176 kB)
+//   0x32000 - 0x38000  NVM3                  ( 24 kB)
+//   0x38000 - 0x40000  image storage, 1 slot ( 32 kB)
+//
+// To make the application fit, this flag stubs out the artwork and the
+// 24 pt font used only by >= 6" panel layouts, and drops the display
+// drivers for panels other than the JD-family. Do not use the resulting
+// binary on large-panel tags.
+#define OEPL_SMALL_FLASH 1
+
+#endif // OEPL_BUILD_FLAGS_H

--- a/firmware/oepl_display.c
+++ b/firmware/oepl_display.c
@@ -92,6 +92,10 @@ static const oepl_display_driver_desc_t* driver = NULL;
 void oepl_display_init(oepl_efr32xg22_displayparams_t* driverconfig)
 {
   switch(driverconfig->ctrl) {
+    // Small-flash builds keep only the JD driver; the others serve
+    // panels that don't appear on small-flash targets, and dropping
+    // them frees a significant amount of flash.
+#if !defined(OEPL_SMALL_FLASH)
     case CTRL_MEMLCD:
       driver = &oepl_display_driver_memlcd;
       break;
@@ -110,9 +114,11 @@ void oepl_display_init(oepl_efr32xg22_displayparams_t* driverconfig)
     case CTRL_UCBWRY:
       driver = &oepl_display_driver_ucbwry;
       break;
+#endif
     case CTRL_JD:
       driver = &oepl_display_driver_jd;
       break;
+#if !defined(OEPL_SMALL_FLASH)
     case CTRL_INTERLEAVED:
       driver = &oepl_display_driver_interleaved;
       break;
@@ -131,6 +137,7 @@ void oepl_display_init(oepl_efr32xg22_displayparams_t* driverconfig)
     case CTRL_GDEW0583Z83:
       driver = &oepl_display_driver_gdew0583z83;
       break;
+#endif
     default:
       oepl_hw_crash(DBG_DISPLAY, false, "Error: Lacking display driver implementation\n");
       return;
@@ -521,7 +528,9 @@ static void add_rendered_content_splash(void)
       C_epdSetFont(&FreeSans9pt7b);
       C_epdPrintf(xres - 17, 310, COLOR_BLACK, ROTATE_270, "FW: %04X-%s", fw, suffix);
       C_epdPrintf(10, yres - 25, COLOR_BLACK, ROTATE_0, "MAC: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], mac[6], mac[7]);
+#if !defined(OEPL_SMALL_FLASH)
       C_addFlashImage(293, 61, COLOR_BLACK, ROTATE_0, newton);
+#endif
       C_addQR(40, 120, 3, 7, "https://openepaperlink.eu/tag/0/%02X/%02X%02X%02X%02X%02X%02X%02X%02X/", hwid, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], mac[6], mac[7]);
       break;
     case SOLUM_M3_BWR_75:
@@ -537,7 +546,9 @@ static void add_rendered_content_splash(void)
       C_epdSetFont(&FreeSans9pt7b);
       C_epdPrintf(xres - 17, 310, COLOR_BLACK, ROTATE_270, "FW: %04X-%s", fw, suffix);
       C_epdPrintf(10, yres - 25, COLOR_BLACK, ROTATE_0, "MAC: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], mac[6], mac[7]);
+#if !defined(OEPL_SMALL_FLASH)
       C_addFlashImage(420, 81, COLOR_BLACK, ROTATE_0, newton);
+#endif
       C_addQR(100, 160, 3, 7, "https://openepaperlink.eu/tag/0/%02X/%02X%02X%02X%02X%02X%02X%02X%02X/", hwid, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], mac[6], mac[7]);
       break;
     case SOLUM_M3_BWR_97:
@@ -548,7 +559,9 @@ static void add_rendered_content_splash(void)
       C_epdSetFont(&FreeSans9pt7b);
       C_epdPrintf(xres - 37, 310, COLOR_BLACK, ROTATE_270, "FW: %04X-%s", fw, suffix);
       C_epdPrintf(10, yres - 25, COLOR_BLACK, ROTATE_0, "MAC: %02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], mac[6], mac[7]);
+#if !defined(OEPL_SMALL_FLASH)
       C_addFlashImage(220, 420, COLOR_BLACK, ROTATE_0, newton);
+#endif
       C_addQR(260, 160, 3, 7, "https://openepaperlink.eu/tag/0/%02X/%02X%02X%02X%02X%02X%02X%02X%02X/", hwid, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], mac[6], mac[7]);
       break;
     default:
@@ -707,8 +720,12 @@ static void add_rendered_content_ap_not_found(void)
     C_epdPrintf(10, 58, COLOR_BLACK, ROTATE_0, "I'll try again in a little while, but you");
     C_epdPrintf(10, 77, COLOR_BLACK, ROTATE_0, "can force a retry now by scanning");
     C_epdPrintf(10, 98, COLOR_BLACK, ROTATE_0, "the NFC-wake area with your phone");
+#if !defined(OEPL_SMALL_FLASH)
     C_addFlashImage(200, 128, COLOR_BLACK, ROTATE_0, pandablack);
+#endif
+#if !defined(OEPL_SMALL_FLASH)
     C_addFlashImage(312, 274, COLOR_RED, ROTATE_0, pandared);
+#endif
   } else if(xres >= 880 && yres >= 528) {
     // 7.5"
     C_epdSetFont(&FreeSansBold18pt7b);
@@ -718,8 +735,12 @@ static void add_rendered_content_ap_not_found(void)
     C_epdPrintf(10, 39, COLOR_BLACK, ROTATE_0, "Couldn't find an AP :(");
     C_epdPrintf(10, 58, COLOR_BLACK, ROTATE_0, "I'll try again in a little while, but you");
     C_epdPrintf(10, 77, COLOR_BLACK, ROTATE_0, "can force a retry now by pressing a button");
+#if !defined(OEPL_SMALL_FLASH)
     C_addFlashImage(200, 128, COLOR_BLACK, ROTATE_0, pandablack);
+#endif
+#if !defined(OEPL_SMALL_FLASH)
     C_addFlashImage(312, 274, COLOR_RED, ROTATE_0, pandared);
+#endif
   } else if(xres >= 600 && yres >= 480) {
     // 6"
     C_epdSetFont(&FreeSansBold18pt7b);
@@ -729,8 +750,12 @@ static void add_rendered_content_ap_not_found(void)
     C_epdPrintf(10, 39, COLOR_BLACK, ROTATE_0, "Couldn't find an AP :(");
     C_epdPrintf(10, 58, COLOR_BLACK, ROTATE_0, "I'll try again in a little while, but you");
     C_epdPrintf(10, 77, COLOR_BLACK, ROTATE_0, "can force a retry now by pressing a button");
+#if !defined(OEPL_SMALL_FLASH)
     C_addFlashImage(0, 96, COLOR_BLACK, ROTATE_0, pandablack);
+#endif
+#if !defined(OEPL_SMALL_FLASH)
     C_addFlashImage(112, 242, COLOR_RED, ROTATE_0, pandared);
+#endif
   } else if(xres >= 792 && yres >= 272) {
     // 5.8" (weird aspect ratio)
     C_epdSetFont(&FreeSansBold18pt7b);

--- a/firmware/oepl_efr32_hwtypes.c
+++ b/firmware/oepl_efr32_hwtypes.c
@@ -47,6 +47,20 @@ static const oepl_efr32xg22_flashconfig_t flashconfig_modchip =
   .EN = GPIO_UNUSED
 };
 
+static const oepl_efr32xg22_flashconfig_t flashconfig_sesimagotag_el042ts1 =
+{
+  // External flash on this tag is not yet identified. Build with the
+  // USART reference kept so the driver compiles, but all pins unused
+  // so no I/O takes place. If OEPL needs external flash at runtime,
+  // probe the board and fill these in.
+  .usart = USART0,
+  .MOSI = GPIO_UNUSED,
+  .MISO = GPIO_UNUSED,
+  .SCK = GPIO_UNUSED,
+  .nCS = GPIO_UNUSED,
+  .EN = GPIO_UNUSED
+};
+
 // ----- Add new flash pinouts here and keep in sync with bootloader ----
 
 // ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ----
@@ -126,7 +140,8 @@ static const oepl_efr32xg22_ledconfig_t ledconfig_brd4402b = {
   .white = {.port = gpioPortD, .pin = 3},
   .blue = GPIO_UNUSED,
   .red = GPIO_UNUSED,
-  .green = GPIO_UNUSED
+  .green = GPIO_UNUSED,
+  .gate = GPIO_UNUSED
 };
 
 static const oepl_efr32xg22_debugconfig_t debugconfig_brd4402b_swo = {
@@ -213,7 +228,8 @@ static const oepl_efr32xg22_ledconfig_t ledconfig_solum = {
   .white = GPIO_UNUSED,
   .blue = {.port = gpioPortC, .pin = 5},
   .red = {.port = gpioPortC, .pin = 6},
-  .green = {.port = gpioPortC, .pin = 7}
+  .green = {.port = gpioPortC, .pin = 7},
+  .gate = GPIO_UNUSED
 };
 
 static const oepl_efr32xg22_nfcconfig_t nfcconfig_solum = {
@@ -280,7 +296,8 @@ static const oepl_efr32xg22_ledconfig_t ledconfig_modchip = {
   .white = GPIO_UNUSED,
   .blue = GPIO_UNUSED,
   .red = GPIO_UNUSED,
-  .green = GPIO_UNUSED
+  .green = GPIO_UNUSED,
+  .gate = GPIO_UNUSED
 };
 
 static const oepl_efr32xg22_debugconfig_t debugconfig_modchip = {
@@ -308,6 +325,89 @@ static const oepl_efr32xg22_tagconfig_t tagconfig_modchip_hd150 = {
 };
 
 // -----------------------------------------------------------------------------
+//                           SES-imagotag EL042TS1 (4.2" BWY, JD family)
+// -----------------------------------------------------------------------------
+// Pin map verified on bench 2026-04-24. Full driver reference lives at
+// ~/personal_repos/epaper_tag/EL042TS1_DRIVER.md (outside this repo).
+//
+// Display bus:   MOSI=PC00, SCK=PC01, nCS=PC02, DC=PC03, nRST=PC04, BUSY=PA07
+// Special:       BS (SPI-mode select) on PC06 MUST be held LOW during SPI
+//                activity. Handled via the `.enable` field with
+//                `idle_state = 1` — common_init briefly drives HIGH before
+//                any SPI happens, common_activate drives LOW for all SPI
+//                (including the RST pulse that latches BS=LOW → 4-wire),
+//                common_deactivate pulls up HIGH after POF. See the detour
+//                writeup at project_pc06_bs_rootcause.md in the bench repo.
+// LEDs:          PB01=green, PB02=red, PB03=blue, PB04=white. All gated
+//                through PC07 (must be HIGH for LEDs to emit). Handling
+//                of the gate pin is a TODO — not yet wired in this port.
+// No button:     confirmed absent on this tag (NFC/RF wake only).
+// External flash: not yet identified. flashconfig pins all GPIO_UNUSED.
+// Debug:         SWO for now, no UART pad identified.
+
+static const oepl_efr32xg22_displayconfig_t displayconfig_sesimagotag_el042ts1 =
+{
+  .usart = USART0,
+  .usart_clock = cmuClock_USART0,
+  .MOSI = {.port = gpioPortC, .pin = 0},
+  .MISO = GPIO_UNUSED,
+  .SCK = {.port = gpioPortC, .pin = 1},
+  .nCS = {.port = gpioPortC, .pin = 2},
+  .nCS2 = GPIO_UNUSED,
+  .DC = {.port = gpioPortC, .pin = 3},
+  .BUSY = {.port = gpioPortA, .pin = 7},
+  .nRST = {.port = gpioPortC, .pin = 4},
+  // Hijacking .enable to pin PC06 (BS) LOW during SPI. See header comment.
+  .enable = {.port = gpioPortC, .pin = 6, .idle_state = 1},
+  .type = EPD_SESIMAGOTAG_EL042TS1
+};
+
+static const oepl_efr32xg22_pinconfig_t pinconfig_sesimagotag_el042ts1 = {
+  .gpio = GPIO_UNUSED,
+  // NFC FD pin not yet identified. Candidates: PD02, PD03 (un-probed).
+  .nfc_fd = GPIO_UNUSED,
+  .nfc_fd_em4wuval = 0,
+  .button1 = GPIO_UNUSED,
+  .button1_em4wuval = 0,
+  .button2 = GPIO_UNUSED,
+  .button2_em4wuval = 0
+};
+
+static const oepl_efr32xg22_ledconfig_t ledconfig_sesimagotag_el042ts1 = {
+  .red    = {.port = gpioPortB, .pin = 2},
+  .green  = {.port = gpioPortB, .pin = 1},
+  .blue   = {.port = gpioPortB, .pin = 3},
+  .white  = {.port = gpioPortB, .pin = 4},
+  // PC07 is the common gate for the RGB+W MOSFETs on this tag.
+  // Must be driven HIGH for the PB01..PB04 channels to actually emit.
+  .gate   = {.port = gpioPortC, .pin = 7}
+};
+
+static const oepl_efr32xg22_debugconfig_t debugconfig_sesimagotag_el042ts1 = {
+  .type = DBG_SWO,
+  .output = {
+    .euart = {
+      .tx = GPIO_UNUSED,
+      .rx = GPIO_UNUSED,
+      .rts = GPIO_UNUSED,
+      .cts = GPIO_UNUSED,
+      .enable = GPIO_UNUSED
+    }
+  }
+};
+
+static const oepl_efr32xg22_tagconfig_t tagconfig_sesimagotag_el042ts1 = {
+  .hwtype = SESIMAGOTAG_EL042TS1,
+  .oepl_hwid = SOLUM_M3_BWRY_42,
+  .flash = &flashconfig_sesimagotag_el042ts1,
+  .display = &displayconfig_sesimagotag_el042ts1,
+  .gpio = &pinconfig_sesimagotag_el042ts1,
+  .led = &ledconfig_sesimagotag_el042ts1,
+  .nfc = NULL,
+  .debug = &debugconfig_sesimagotag_el042ts1
+};
+
+// -----------------------------------------------------------------------------
 //                           Other hardware
 // -----------------------------------------------------------------------------
 // ----- Add new HW types here ----
@@ -323,6 +423,7 @@ static const oepl_efr32xg22_tagconfig_t* tagdb[] = {
   &tagconfig_brd4402b_epd,
   &tagconfig_solum,
   &tagconfig_modchip_hd150,
+  &tagconfig_sesimagotag_el042ts1,
 };
 
 const oepl_efr32xg22_tagconfig_t* oepl_efr32xg22_get_config(void)
@@ -696,6 +797,24 @@ bool oepl_efr32xg22_get_displayparams(oepl_efr32xg22_displayparams_t* displaypar
     displayparams->mirrorX = false;
     displayparams->mirrorY = false;
     displayparams->ctrl = CTRL_GDEW0583Z83;
+    return true;
+  } else if(tagcfg->display->type == EPD_SESIMAGOTAG_EL042TS1) {
+    // SES-imagotag EL042TS1: 400x300 BWY, JD-family controller.
+    // No autodetect via userdata — this tag's userdata format predates
+    // the Solum unification (offset 0x09 reads 0x30 on-bench, not the
+    // 0x2B Solum uses for JD 4.2"), so we hardcode the params.
+    displayparams->xres = 400;
+    displayparams->yres = 300;
+    displayparams->xres_working = 400;
+    displayparams->yres_working = 300;
+    displayparams->xoffset = 0;
+    displayparams->yoffset = 0;
+    displayparams->have_thirdcolor = true;
+    displayparams->have_fourthcolor = true;   // BWRY: black/white/red/yellow
+    displayparams->swapXY = false;
+    displayparams->mirrorX = false;
+    displayparams->mirrorY = false;
+    displayparams->ctrl = CTRL_JD;
     return true;
   // ----- Add new HW types here ----
 

--- a/firmware/oepl_efr32_hwtypes.c
+++ b/firmware/oepl_efr32_hwtypes.c
@@ -380,11 +380,15 @@ static const oepl_efr32xg22_ledconfig_t ledconfig_sesimagotag_el042ts1 = {
   .white  = {.port = gpioPortB, .pin = 4},
   // PC07 is the common gate for the RGB+W MOSFETs on this tag.
   // Must be driven HIGH for the PB01..PB04 channels to actually emit.
-  .gate   = {.port = gpioPortC, .pin = 7}
+  .gate   = {.port = gpioPortC, .pin = 7},
+  // Channels switch low-side MOSFETs: pin HIGH = LED on.
+  .active_high = true
 };
 
 static const oepl_efr32xg22_debugconfig_t debugconfig_sesimagotag_el042ts1 = {
-  .type = DBG_SWO,
+  // SWO is unusable on this tag (PA03 is tied to ground), so debug
+  // output goes over RTT through the SWD connection instead.
+  .type = DBG_RTT,
   .output = {
     .euart = {
       .tx = GPIO_UNUSED,

--- a/firmware/oepl_efr32_hwtypes.h
+++ b/firmware/oepl_efr32_hwtypes.h
@@ -43,6 +43,7 @@
 #define OEPL_EFR32XG22_HWTYPE_DISPLAYDATA_SUFIFT27PL4A  (0x05)
 #define OEPL_EFR32XG22_HWTYPE_CUSTOM_9_7                (0x06)
 #define OEPL_EFR32XG22_HWTYPE_MODCHIP_HD150             (0x07)
+#define OEPL_EFR32XG22_HWTYPE_SESIMAGOTAG_EL042TS1      (0x08)
 // ----- Add new HW types here and keep in sync with bootloader ----
 
 // ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ----
@@ -71,6 +72,7 @@ typedef enum {
   DISPLAYDATA_SUFIFT27PL4A  = OEPL_EFR32XG22_HWTYPE_DISPLAYDATA_SUFIFT27PL4A,
   CUSTOM_9_7                = OEPL_EFR32XG22_HWTYPE_CUSTOM_9_7,
   MODCHIP_HD150             = OEPL_EFR32XG22_HWTYPE_MODCHIP_HD150,
+  SESIMAGOTAG_EL042TS1      = OEPL_EFR32XG22_HWTYPE_SESIMAGOTAG_EL042TS1,
   // ----- Add new HW types here and keep in sync with bootloader ----
 
   // ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ----
@@ -97,6 +99,7 @@ typedef enum {
   EPD_SOLUM_AUTODETECT,
   EPD_SEEED_264_176_BWR,
   EPD_HD150,
+  EPD_SESIMAGOTAG_EL042TS1,
 } oepl_efr32xg22_displaytype_t;
 
 typedef struct {
@@ -144,6 +147,11 @@ typedef struct {
   oepl_efr32xg22_gpio_t green;
   oepl_efr32xg22_gpio_t blue;
   oepl_efr32xg22_gpio_t white;
+  // Optional LED-circuit enable/gate. Some boards (e.g. SES-imagotag
+  // EL042TS1) wire the colour-channel MOSFETs' common rail through an
+  // extra MCU pin that must be driven HIGH before any LED will emit.
+  // Leave as GPIO_UNUSED (port == gpioPortInvalid) when not present.
+  oepl_efr32xg22_gpio_t gate;
 } oepl_efr32xg22_ledconfig_t;
 
 typedef struct {

--- a/firmware/oepl_efr32_hwtypes.h
+++ b/firmware/oepl_efr32_hwtypes.h
@@ -152,6 +152,11 @@ typedef struct {
   // extra MCU pin that must be driven HIGH before any LED will emit.
   // Leave as GPIO_UNUSED (port == gpioPortInvalid) when not present.
   oepl_efr32xg22_gpio_t gate;
+  // Channel polarity. Default (false) is the classic direct-drive wiring
+  // where the pin sinks current: LOW = LED on. Boards that switch the
+  // LEDs through low-side MOSFETs (e.g. SES-imagotag EL042TS1) need
+  // true: HIGH = LED on.
+  bool active_high;
 } oepl_efr32xg22_ledconfig_t;
 
 typedef struct {

--- a/firmware/oepl_flash_driver.c
+++ b/firmware/oepl_flash_driver.c
@@ -52,8 +52,11 @@ uint32_t HAL_flashRead(uint32_t address, uint8_t *buffer, uint32_t num)
 {
   init_flashdriver();
 
-  if(cfg == NULL || cfg->flash == NULL) {
-    oepl_hw_crash(DBG_FLASH, false, "Unknown flash configuration\n");
+  if(cfg == NULL || cfg->flash == NULL || cfg->flash->nCS.port == gpioPortInvalid) {
+    // No external flash on this tag: bulk storage lives in internal
+    // flash, which is memory-mapped — read it directly.
+    memcpy(buffer, (const void*)address, num);
+    return num;
   }
 
   setup_spi();

--- a/firmware/oepl_hw_abstraction.c
+++ b/firmware/oepl_hw_abstraction.c
@@ -73,6 +73,7 @@ static const sl_power_manager_em_transition_event_info_t event_info = {
 
 static uint8_t button1_hwval, button2_hwval, gpio_hwval, nfcfd_hwval, nfcpwr_hwval, nfcsda_hwval;
 static uint8_t white_hwval, red_hwval, blue_hwval, green_hwval;
+static bool led_active_high = false;
 static void* gpio_cb = NULL;
 
 static bool is_devkit = false;
@@ -162,9 +163,12 @@ void oepl_hw_init(void)
 
   // Setup debugprint infrastructure
   extern sl_iostream_instance_info_t sl_iostream_instance_euart_debug_info;
-  #if SL_CATALOG_IOSTREAM_RTT_PRESENT
+  // Note: the iostream_rtt component does not contribute a
+  // SL_CATALOG_IOSTREAM_RTT_PRESENT define to sl_component_catalog.h
+  // (unlike iostream_swo), so we can't gate on the catalog here. The
+  // component is unconditionally part of the project (.slcp), so
+  // reference it directly.
   extern sl_iostream_instance_info_t sl_iostream_instance_rtt_info;
-  #endif
   extern sl_iostream_instance_info_t sl_iostream_instance_swo_info;
 
   if(tagconfig->debug->type != DBG_SWO) {
@@ -185,11 +189,9 @@ void oepl_hw_init(void)
     case DBG_SWO:
       sl_iostream_set_system_default(sl_iostream_instance_swo_info.handle);
       break;
-    #if SL_CATALOG_IOSTREAM_RTT_PRESENT
     case DBG_RTT:
       sl_iostream_set_system_default(sl_iostream_instance_rtt_info.handle);
       break;
-    #endif
     case DBG_EUART:
       // Adjust the pinout for the EUART
       GPIO_PinModeSet(tagconfig->debug->output.euart.tx.port, tagconfig->debug->output.euart.tx.pin, gpioModePushPull, 1);
@@ -283,26 +285,29 @@ void oepl_hw_init(void)
     if(tagconfig->led->gate.port != gpioPortInvalid) {
       GPIO_PinModeSet(tagconfig->led->gate.port, tagconfig->led->gate.pin, gpioModePushPull, 1);
     }
+    led_active_high = tagconfig->led->active_high;
+    // Idle (off) level depends on channel polarity
+    unsigned int led_idle = led_active_high ? 0 : 1;
     if(tagconfig->led->white.port != gpioPortInvalid) {
-      GPIO_PinModeSet(tagconfig->led->white.port, tagconfig->led->white.pin, gpioModePushPull, 1);
+      GPIO_PinModeSet(tagconfig->led->white.port, tagconfig->led->white.pin, gpioModePushPull, led_idle);
       white_hwval =  0x80 | tagconfig->led->white.port << 4| tagconfig->led->white.pin;
     } else {
       white_hwval = 0;
     }
     if(tagconfig->led->red.port != gpioPortInvalid) {
-      GPIO_PinModeSet(tagconfig->led->red.port, tagconfig->led->red.pin, gpioModePushPull, 1);
+      GPIO_PinModeSet(tagconfig->led->red.port, tagconfig->led->red.pin, gpioModePushPull, led_idle);
       red_hwval =  0x80 | tagconfig->led->red.port << 4| tagconfig->led->red.pin;
     } else {
       red_hwval = 0;
     }
     if(tagconfig->led->green.port != gpioPortInvalid) {
-      GPIO_PinModeSet(tagconfig->led->green.port, tagconfig->led->green.pin, gpioModePushPull, 1);
+      GPIO_PinModeSet(tagconfig->led->green.port, tagconfig->led->green.pin, gpioModePushPull, led_idle);
       green_hwval =  0x80 | tagconfig->led->green.port << 4| tagconfig->led->green.pin;
     } else {
       green_hwval = 0;
     }
     if(tagconfig->led->blue.port != gpioPortInvalid) {
-      GPIO_PinModeSet(tagconfig->led->blue.port, tagconfig->led->blue.pin, gpioModePushPull, 1);
+      GPIO_PinModeSet(tagconfig->led->blue.port, tagconfig->led->blue.pin, gpioModePushPull, led_idle);
       blue_hwval =  0x80 | tagconfig->led->blue.port << 4| tagconfig->led->blue.pin;
     } else {
       blue_hwval = 0;
@@ -534,6 +539,18 @@ void oepl_hw_init(void)
 
   // Cache our HWID
   oepl_nvm_setting_get(OEPL_HWID, &hwid, sizeof(hwid));
+
+  // Refresh NVM if our current config reports a different (and non-zero) hwid.
+  // Without this, an older firmware boot that happened to return 0 (because
+  // hwtype lookup failed before being fixed) leaves NVM stuck at 0, and the
+  // AP keeps mis-identifying us. Re-syncing on every boot keeps NVM aligned
+  // with the build's actual config.
+  uint8_t current_hwid = oepl_efr32xg22_get_oepl_hwid();
+  if(current_hwid != 0 && current_hwid != hwid) {
+    DPRINTF("HWID drift: NVM=0x%02x, config=0x%02x — updating NVM\n", hwid, current_hwid);
+    oepl_nvm_setting_set(OEPL_HWID, &current_hwid, sizeof(current_hwid));
+    hwid = current_hwid;
+  }
   DPRINTF("Hello OEPL tag type 0x%02x\n", hwid);
 
   size_t slots, slot_size;
@@ -553,32 +570,32 @@ void oepl_hw_init(void)
   oepl_display_init(&displayconfig);
 }
 
+static void led_drive(uint8_t hwval, bool on)
+{
+  // The default LED wiring is active-low (pin sinks the LED current);
+  // boards with low-side MOSFET switches are active-high.
+  if(on != led_active_high) {
+    GPIO_PinOutClear((GPIO_Port_TypeDef)((hwval & 0x70) >> 4), hwval & 0x0F);
+  } else {
+    GPIO_PinOutSet((GPIO_Port_TypeDef)((hwval & 0x70) >> 4), hwval & 0x0F);
+  }
+}
+
 void oepl_hw_set_led(uint8_t color, bool on)
 {
   if(red_hwval || green_hwval || blue_hwval) {
     // todo: color support using PWM on a timer
-    (void) color;
-    if(on) {
-      if(color & 0b11100000)
-      GPIO_PinOutClear((red_hwval & 0x70) >> 4, red_hwval & 0x0F);
-      if(color & 0b00011100)
-      GPIO_PinOutClear((green_hwval & 0x70) >> 4, green_hwval & 0x0F);
-      if(color & 0b00000011)
-      GPIO_PinOutClear((blue_hwval & 0x70) >> 4, blue_hwval & 0x0F);
-    } else {
-      if(color & 0b11100000)
-      GPIO_PinOutSet((red_hwval & 0x70) >> 4, red_hwval & 0x0F);
-      if(color & 0b00011100)
-      GPIO_PinOutSet((green_hwval & 0x70) >> 4, green_hwval & 0x0F);
-      if(color & 0b00000011)
-      GPIO_PinOutSet((blue_hwval & 0x70) >> 4, blue_hwval & 0x0F);
+    if(color & 0b11100000) {
+      led_drive(red_hwval, on);
+    }
+    if(color & 0b00011100) {
+      led_drive(green_hwval, on);
+    }
+    if(color & 0b00000011) {
+      led_drive(blue_hwval, on);
     }
   } else if(white_hwval) {
-    if(on) {
-      GPIO_PinOutClear((white_hwval & 0x70) >> 4, white_hwval & 0x0F);
-    } else {
-      GPIO_PinOutSet((white_hwval & 0x70) >> 4, white_hwval & 0x0F);
-    }
+    led_drive(white_hwval, on);
   }
 }
 

--- a/firmware/oepl_hw_abstraction.c
+++ b/firmware/oepl_hw_abstraction.c
@@ -277,6 +277,12 @@ void oepl_hw_init(void)
 
   // Setup led(s)
   if(tagconfig->led) {
+    // Some tags (e.g. SES-imagotag EL042TS1) gate the LED MOSFETs through
+    // a shared enable pin. Drive it HIGH before configuring the colour
+    // channels so the first LED pulse isn't swallowed by a still-LOW gate.
+    if(tagconfig->led->gate.port != gpioPortInvalid) {
+      GPIO_PinModeSet(tagconfig->led->gate.port, tagconfig->led->gate.pin, gpioModePushPull, 1);
+    }
     if(tagconfig->led->white.port != gpioPortInvalid) {
       GPIO_PinModeSet(tagconfig->led->white.port, tagconfig->led->white.pin, gpioModePushPull, 1);
       white_hwval =  0x80 | tagconfig->led->white.port << 4| tagconfig->led->white.pin;

--- a/firmware/oepl_nvm.c
+++ b/firmware/oepl_nvm.c
@@ -2,9 +2,12 @@
 //                                   Includes
 // -----------------------------------------------------------------------------
 #include "em_device.h"
+#include "em_msc.h"
+#include "em_system.h"
 #include "oepl_nvm.h"
 #include "oepl_hw_abstraction.h"
 #include "oepl_flash_driver.h"
+#include "oepl_efr32_hwtypes.h"
 
 #include "oepl-proto.h"
 #include "nvm3.h"
@@ -32,6 +35,15 @@
 #define NVM3_OBJECT_ID_IMAGE_METADATA_MAX   0x2010
 
 #define NVM3_MARKER_VALUE                   0xCAFEFACEUL
+
+// Tags without an external SPI flash keep bulk image storage in internal
+// flash, between the end of the app+NVM3 region (linker_nvm_end, the top
+// of the linker's FLASH region) and the end of the physical flash. The
+// physical size is taken from DEVINFO at runtime, because the part we
+// link against (F512) can have more flash than the part on the board
+// (the SES-imagotag EL042TS1 carries a 256 kB FG22).
+extern char linker_nvm_end;
+#define INTERNAL_BULK_STORAGE_BASE          ((uint32_t)&linker_nvm_end)
 
 // -----------------------------------------------------------------------------
 //                              Macros and Typedefs
@@ -64,6 +76,9 @@ typedef struct {
 //                          Static Function Declarations
 // -----------------------------------------------------------------------------
 static oepl_nvm_status_t check_fwu_md5(void);
+static bool bulk_storage_is_internal(void);
+static oepl_nvm_status_t internal_storage_erase(uint32_t address, size_t length);
+static oepl_nvm_status_t internal_storage_write(uint32_t address, const uint8_t* bytes, size_t length);
 
 // -----------------------------------------------------------------------------
 //                                Global Variables
@@ -100,6 +115,27 @@ oepl_nvm_status_t oepl_nvm_init_default(void)
   // Bugfix: deinit the bootloader explicitly since it might not have realized
   bootloader_deinit();
   Ecode_t nvm_status = nvm3_readData(nvm3_defaultHandle, NVM3_OBJECT_ID_CONFIG, &devconfig, sizeof(devconfig));
+  if(nvm_status == ECODE_NVM3_ERR_NOT_OPENED) {
+    // The nvm3_initDefault() call in sl_platform_init() failed and its return
+    // code was discarded. It runs right after bootloader_init(), which can
+    // interfere with flash access; now that the bootloader is deinited, retry
+    // the open and log the original failure reason if it persists.
+    nvm_status = nvm3_initDefault();
+    DPRINTF("NVM3 was not open at boot; reopen attempt returned %08lX\n", nvm_status);
+    if(nvm_status == ECODE_NVM3_ERR_NO_VALID_PAGES) {
+      // The NVM3 area contains non-NVM3 data, e.g. remnants of a previous
+      // firmware with a different flash layout. Erase the area and retry.
+      DPRINTF("Erasing NVM3 area at %p (%d bytes) and retrying\n",
+              nvm3_defaultInit->nvmAdr, nvm3_defaultInit->nvmSize);
+      if(internal_storage_erase((uint32_t)nvm3_defaultInit->nvmAdr, nvm3_defaultInit->nvmSize) == NVM_SUCCESS) {
+        nvm_status = nvm3_initDefault();
+        DPRINTF("NVM3 open after erase returned %08lX\n", nvm_status);
+      }
+    }
+    if(nvm_status == ECODE_OK) {
+      nvm_status = nvm3_readData(nvm3_defaultHandle, NVM3_OBJECT_ID_CONFIG, &devconfig, sizeof(devconfig));
+    }
+  }
   if(nvm_status != ECODE_OK) {
     DPRINTF("Unable to read/find device initial settings, %08lX\n", nvm_status);
     return NVM_ERROR;
@@ -117,18 +153,99 @@ oepl_nvm_status_t oepl_nvm_init_default(void)
   return NVM_SUCCESS;
 }
 
+static bool bulk_storage_is_internal(void)
+{
+  const oepl_efr32xg22_tagconfig_t* tagcfg = oepl_efr32xg22_get_config();
+  return tagcfg == NULL
+         || tagcfg->flash == NULL
+         || tagcfg->flash->nCS.port == gpioPortInvalid;
+}
+
+static oepl_nvm_status_t internal_storage_erase(uint32_t address, size_t length)
+{
+  MSC_Init();
+  for(uint32_t page = address; page < address + length; page += FLASH_PAGE_SIZE) {
+    if(MSC_ErasePage((uint32_t*)page) != mscReturnOk) {
+      MSC_Deinit();
+      DPRINTF("Internal flash erase failed at 0x%08lx\n", page);
+      return NVM_ERROR;
+    }
+  }
+  MSC_Deinit();
+  return NVM_SUCCESS;
+}
+
+static oepl_nvm_status_t internal_storage_write(uint32_t address, const uint8_t* bytes, size_t length)
+{
+  MSC_Status_TypeDef status;
+  // Image block offsets are 4k-aligned, so the address is always
+  // word-aligned. The length of the last block of an image may not be:
+  // pad the tail out to a full word with erased-state bytes.
+  size_t aligned_length = length & ~3UL;
+  MSC_Init();
+  status = MSC_WriteWord((uint32_t*)address, bytes, aligned_length);
+  if(status == mscReturnOk && aligned_length < length) {
+    uint8_t tail[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+    memcpy(tail, &bytes[aligned_length], length - aligned_length);
+    status = MSC_WriteWord((uint32_t*)(address + aligned_length), tail, sizeof(tail));
+  }
+  MSC_Deinit();
+  if(status != mscReturnOk) {
+    DPRINTF("Internal flash write failed at 0x%08lx (%d)\n", address, status);
+    return NVM_ERROR;
+  }
+  return NVM_SUCCESS;
+}
+
 oepl_nvm_status_t oepl_nvm_factory_reset(uint8_t hwid)
 {
   oepl_nvm_status_t function_status = NVM_ERROR;
   Ecode_t nvm_status = nvm3_eraseAll(nvm3_defaultHandle);
   if(nvm_status != ECODE_OK) {
-    DPRINTF("Failed resetting to factory\n");
+    DPRINTF("Failed resetting to factory, %08lX\n", nvm_status);
     return NVM_ERROR;
   }
 
   devconfig.marker = NVM3_MARKER_VALUE;
   devconfig.hwid = hwid;
-  
+
+  if(bulk_storage_is_internal()) {
+    // No external flash on this tag: bulk image storage lives in the top
+    // region of internal flash instead of a bootloader-managed SPI flash.
+    // There is no FWU staging slot in this mode (flash via SWD instead).
+    uint32_t flash_size = (uint32_t)SYSTEM_GetFlashSize() * 1024UL;
+    if(flash_size <= INTERNAL_BULK_STORAGE_BASE) {
+      DPRINTF("Internal flash (%ldB) too small for bulk storage\n", flash_size);
+      return NVM_ERROR;
+    }
+    devconfig.fwu_slot_size = 0;
+    devconfig.bulk_storage_base_address = INTERNAL_BULK_STORAGE_BASE;
+    devconfig.bulk_storage_size = flash_size - INTERNAL_BULK_STORAGE_BASE;
+    devconfig.bulk_storage_pagesize = FLASH_PAGE_SIZE;
+    DPRINTF("Using internal bulk storage at 0x%08lx, %ldB in pages of %ldB\n",
+            devconfig.bulk_storage_base_address,
+            devconfig.bulk_storage_size,
+            devconfig.bulk_storage_pagesize);
+
+    function_status = internal_storage_erase(devconfig.bulk_storage_base_address,
+                                             devconfig.bulk_storage_size);
+    if(function_status != NVM_SUCCESS) {
+      DPRINTF("Failed erasing internal bulk storage\n");
+      return function_status;
+    }
+
+    nvm3_writeData(nvm3_defaultHandle, NVM3_OBJECT_ID_CONFIG, &devconfig, sizeof(devconfig));
+    DPRINTF("Stored new devconfig\n");
+
+    function_status = oepl_nvm_setting_set_default(OEPL_RAW_TAGSETTINGS);
+    if(function_status == NVM_SUCCESS) {
+      DPRINTF("Stored default tagconfig\n");
+    } else {
+      DPRINTF("Didn't manage to set tagconfig?\n");
+    }
+    return function_status;
+  }
+
   // Autodetect FWU and storage size through the bootloader flash driver
   int32_t status;
   BootloaderStorageSlot_t slotInfo;
@@ -559,6 +676,12 @@ oepl_nvm_status_t oepl_fwu_get_highest_block_written(size_t* block_idx)
 
 oepl_nvm_status_t oepl_fwu_write(size_t block_idx, const uint8_t bytes[4096], size_t actual_length)
 {
+  if(devconfig.fwu_slot_size == 0) {
+    // Tags on internal bulk storage have no FWU staging slot
+    DPRINTF("FWU not supported without staging storage\n");
+    return NVM_NOT_SUPPORTED;
+  }
+
   size_t highest_written;
   if(oepl_fwu_get_highest_block_written(&highest_written) != NVM_SUCCESS) {
     return NVM_ERROR;
@@ -938,35 +1061,35 @@ oepl_nvm_status_t oepl_nvm_erase_image(size_t img_idx)
   }
 
   // Erase the slot in bulk storage first
-  int32_t btl_status;
-  oepl_hw_flash_wake();
-  if((btl_status = bootloader_init()) != BOOTLOADER_OK) {
-    DPRINTF("Failed BTL init with %08lx\n", btl_status);
-    goto exit;
-  }
+  if(bulk_storage_is_internal()) {
+    retval = internal_storage_erase(devconfig.bulk_storage_base_address + img_idx * slot_size, slot_size);
+    if(retval != NVM_SUCCESS) {
+      return retval;
+    }
+  } else {
+    int32_t btl_status;
+    oepl_hw_flash_wake();
+    if((btl_status = bootloader_init()) != BOOTLOADER_OK) {
+      DPRINTF("Failed BTL init with %08lx\n", btl_status);
+      oepl_hw_flash_deepsleep();
+      return NVM_ERROR;
+    }
 
-  btl_status = bootloader_eraseRawStorage(devconfig.bulk_storage_base_address + img_idx * slot_size, slot_size);
-  if(btl_status != BOOTLOADER_OK) {
-    goto done;
+    btl_status = bootloader_eraseRawStorage(devconfig.bulk_storage_base_address + img_idx * slot_size, slot_size);
+    bootloader_deinit();
+    oepl_hw_flash_deepsleep();
+    if(btl_status != BOOTLOADER_OK) {
+      return NVM_ERROR;
+    }
   }
 
   // Then erase the accompanying metadata
   Ecode_t nvm_status = nvm3_deleteObject(nvm3_defaultHandle, NVM3_OBJECT_ID_IMAGE_METADATA_BASE + img_idx);
   if(nvm_status == ECODE_NVM3_OK ||
      nvm_status == ECODE_NVM3_ERR_KEY_NOT_FOUND) {
-    retval = NVM_SUCCESS;
+    return NVM_SUCCESS;
   } else {
-    retval = NVM_ERROR;
-  }
-
-  done:
-  bootloader_deinit();
-  exit:
-  oepl_hw_flash_deepsleep();
-  if(btl_status != BOOTLOADER_OK) {
     return NVM_ERROR;
-  } else {
-    return retval;
   }
 }
 
@@ -1083,14 +1206,18 @@ oepl_nvm_status_t oepl_nvm_write_image_bytes(size_t img_idx, size_t offset, cons
     return NVM_NOT_SUPPORTED;
   }
 
+  DPRINTF("Write %d to addr 0x%08x\n", length, devconfig.bulk_storage_base_address + img_idx * slot_size + offset);
+
+  if(bulk_storage_is_internal()) {
+    return internal_storage_write(devconfig.bulk_storage_base_address + img_idx * slot_size + offset, bytes, length);
+  }
+
   int32_t btl_status;
   oepl_hw_flash_wake();
   if((btl_status = bootloader_init()) != BOOTLOADER_OK) {
     DPRINTF("Failed BTL init with %08lx\n", btl_status);
     goto exit;
   }
-
-  DPRINTF("Write %d to addr 0x%08x\n", length, devconfig.bulk_storage_base_address + img_idx * slot_size + offset);
 
   // Todo: does the bootloader really modify its input byte buffer?
   btl_status = bootloader_writeRawStorage(devconfig.bulk_storage_base_address + img_idx * slot_size + offset, (uint8_t*)bytes, length);


### PR DESCRIPTION
WORK IN PROGRESS

## What this adds

A new hardware variant for the **SES-imagotag EL042TS1** shelf label: 4.2" 400×300 BWRY panel (JD79653-family controller, SoluM-customized command set) on an **EFR32FG22 with only 256 kB flash and no external SPI flash**. Verified end-to-end on hardware: the tag associates with an AP, downloads images, stores them, and renders all four colours.

Along the way this fixes several issues that affect other tags too:

### Bug fixes (independent of the new variant)

- **`DBG_RTT` was dead code.** GSDK's `iostream_rtt` component never contributes `SL_CATALOG_IOSTREAM_RTT_PRESENT` to `sl_component_catalog.h` (unlike `iostream_swo`), so the `#if`-guarded `case DBG_RTT:` could never compile in. Selecting `DBG_RTT` fell into the `default:` infinite-sleep loop and bricked the boot before display/radio init. Fixed by referencing the always-present instance directly. (This tag needs RTT — its SWO pin is tied to ground.)
- **`nvm3_initDefault()`'s return code is discarded** in `sl_platform_init`. `oepl_nvm_init_default` now retries the open, logs the real error, and self-heals a `NO_VALID_PAGES` area (e.g. remnants of a previous image after a flash-layout change) by erasing and re-opening.

### New capabilities

- **Internal-flash bulk storage backend** for tags without external SPI flash. Selected at runtime when the tagconfig has no flash chip configured (`nCS == gpioPortInvalid`): image slots live between `linker_nvm_end` and the end of physical flash (sized via `SYSTEM_GetFlashSize()`, since the part on the board can be smaller than the linked-against device), MSC for erase/write, memory-mapped reads in `HAL_flashRead`. FWU-over-the-air is cleanly rejected when there is no staging slot.
- **LED channel polarity** (`active_high` in the LED config) for boards that switch LEDs through low-side MOSFETs, plus an optional shared LED gate pin.
- **`OEPL_SMALL_FLASH`** (see "open question" below): trims the application to fit a 256 kB part — drops the non-JD display drivers, the ≥6" splash artwork (panda/newton) and the 24 pt font, none of which can be used on a small-flash target. With it, app + NVM3 fit in `0x6000–0x38000` leaving a 32 kB image slot at `0x38000–0x40000`.

### EL042TS1 specifics

- Display init uses the M3 BWRY 4.2" register set with two quirks reverse-engineered on the bench: **PON must precede DTM1** (otherwise banded noise), and **DRF (0x12) requires a data byte** — a bare 0x12 is a silent no-op on this SoluM silicon.
- No buttons, no NFC FD wired; wake is RF only.
- Bootloader: patched Solum SPIF base with idbyte 0x08 (SFDP probe fails harmlessly — there is no flash chip; the app's display init resets the panel afterwards).

## Open question for maintainers

`OEPL_SMALL_FLASH` is currently enabled unconditionally in `firmware/oepl_build_flags.h`, and the `.slcp` flash size is set for the 256 kB layout — that matches this variant but would change the universal binary for large-panel tags. Happy to rework this into whatever fits the project best (a second build profile/slcp, a CI matrix dimension, or gating the layout off the bootloader idbyte). Guidance welcome — that's the one piece I didn't want to decide unilaterally.

## Test status

- Verified on a physical EL042TS1: boot, NVM3, association, image download, 4-colour render (black/white/red/yellow), LED patterns, RTT debug output.
- Other variants compile; I don't own the hardware to runtime-test them, and as noted above the small-flash trims would currently affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)