### PR TITLE
Add support for 3.5" BWRY EL035F5C4C.

### DIFF
--- a/firmware/drivers/oepl_display_driver_jd.c
+++ b/firmware/drivers/oepl_display_driver_jd.c
@@ -184,7 +184,8 @@ static void display_refresh_and_wait(void)
      (params->x_res_effective == 184 && params->y_res_effective == 360) ||
      (params->x_res_effective == 200 && params->y_res_effective == 200) ||
      (params->x_res_effective == 160 && params->y_res_effective == 296) ||
-     (params->x_res_effective == 400 && params->y_res_effective == 300)) {
+     (params->x_res_effective == 400 && params->y_res_effective == 300) ||
+     (params->y_res_effective == 384 && params->x_res_effective == 184)) {
     oepl_display_driver_wait(10);
     DPRINTF("Turn on EPD power rails\n");
     EMIT_INSTRUCTION_STATIC_DATA(0x04, {0x00});
@@ -342,6 +343,22 @@ static void display_reinit(void)
   // From captured waveform
      EMIT_INSTRUCTION_STATIC_DATA(0x4D, {0x78});
      EMIT_INSTRUCTION_STATIC_DATA(0x00, {0x47, 0x09});
+     EMIT_INSTRUCTION_STATIC_DATA(0x01, {0x07});
+     EMIT_INSTRUCTION_STATIC_DATA(0x03, {0x10, 0x54, 0x44});
+     EMIT_INSTRUCTION_STATIC_DATA(0x06, {0x0F, 0x0A, 0x2F, 0x25, 0x22, 0x2E, 0x21});
+     EMIT_INSTRUCTION_STATIC_DATA(0x50, {0x37});
+     EMIT_INSTRUCTION_STATIC_DATA(0x60, {0x02, 0x02});
+     EMIT_INSTRUCTION_VAR_DATA(EPD_CMD_RESOLUTION_SETTING, {params->x_res_effective >> 8, params->x_res_effective & 0xFF, params->y_res_effective >> 8, params->y_res_effective & 0xFF});
+     EMIT_INSTRUCTION_STATIC_DATA(0xE7, {0x1C});
+     EMIT_INSTRUCTION_STATIC_DATA(0xE3, {0x22});
+     EMIT_INSTRUCTION_STATIC_DATA(0xB4, {0xD0});
+     EMIT_INSTRUCTION_STATIC_DATA(0xB5, {0x03});
+     EMIT_INSTRUCTION_STATIC_DATA(0xE9, {0x01});
+     EMIT_INSTRUCTION_STATIC_DATA(0x30, {0x08});
+  } else if(params->x_res_effective == 184 && params->y_res_effective == 384) {
+  // From captured waveform https://github.com/skiphansen/dmitrygr-einkTags/blob/master/docs/DSLogic/Solum_EL035F5C4C.txt
+     EMIT_INSTRUCTION_STATIC_DATA(0x4D, {0x78});
+     EMIT_INSTRUCTION_STATIC_DATA(0x00, {0x07, 0x09});
      EMIT_INSTRUCTION_STATIC_DATA(0x01, {0x07});
      EMIT_INSTRUCTION_STATIC_DATA(0x03, {0x10, 0x54, 0x44});
      EMIT_INSTRUCTION_STATIC_DATA(0x06, {0x0F, 0x0A, 0x2F, 0x25, 0x22, 0x2E, 0x21});

--- a/firmware/oepl_efr32_hwtypes.c
+++ b/firmware/oepl_efr32_hwtypes.c
@@ -393,6 +393,8 @@ uint8_t oepl_efr32xg22_get_oepl_hwid(void)
         return SOLUM_M3_BWRY_29;
       case STYPE_SIZE_30_BWRY:
         return SOLUM_M3_BWRY_30;
+      case STYPE_SIZE_35_BWRY:
+        return SOLUM_M3_BWRY_35;
       case STYPE_SIZE_42_BWRY:
         return SOLUM_M3_BWRY_42;
       case STYPE_SIZE_43_BWRY:
@@ -577,6 +579,9 @@ bool oepl_efr32xg22_get_displayparams(oepl_efr32xg22_displayparams_t* displaypar
       case STYPE_SIZE_029_FREEZER:
         displayparams->swapXY = true;
         displayparams->xoffset = 8;
+        break;
+      case STYPE_SIZE_35_BWRY:
+        displayparams->swapXY = true;
         break;
       case STYPE_SIZE_042:
         displayparams->mirrorY = true;


### PR DESCRIPTION
Requires a new 92.json file (attached) which I have not committed yet.

A full binary Beta release incorporating this PR is available [here](https://github.com/skiphansen/Tag_FW_EFR32xG22/blob/dev/full_binaries/v43/SOLUM_AUTODETECT_FULL_EL035F5C4C_beta.s37) for anyone that wants to help test.

[92.json](https://github.com/user-attachments/files/31849107/92.json)