### PR TITLE
Add Solum ctrltype 0x37 (1.6" 200px BWRY, EL016F5C4C)

### DIFF
--- a/firmware/oepl_efr32_hwtypes.c
+++ b/firmware/oepl_efr32_hwtypes.c
@@ -517,6 +517,8 @@ bool oepl_efr32xg22_get_displayparams(oepl_efr32xg22_displayparams_t* displaypar
       // Maybe these are the same?
       case 0x1C:
         // 1.6" BWRY
+      case 0x37:
+        // 1.6" 200px BWRY, EL016F5C4C MFD 2025-06, neuere ctrltype-Revision
       case 0x1E:
         // 2.2" BWRY WT
       case 0x20:


### PR DESCRIPTION
## Summary
- See also: https://github.com/OpenEPaperLink/Tag_FW_EFR32xG22/issues/31#issue-5396630939
- A Solum EL016F5C4C (1.6" BWRY panel, MFD Jun.2025) shipped with `ctrltype` byte `0x37` in its userdata (offset 0x09), which `oepl_efr32xg22_get_displayparams()` in `firmware/oepl_efr32_hwtypes.c` doesn't recognize.
- Tag type `0x16` (`STYPE_SIZE_16_BWRY_HIGHRES`) *is* already mapped correctly, but the unknown `ctrltype` makes the `switch(solum_ctrltype)` fall through to `default: return false`, so display init aborts and the tag sleeps forever without ever checking in (log: `Hello OEPL tag type 0x4A` → `Error: no valid display configuration`).
- This is the same 1.6" 200px BWRY panel already supported via `ctrltype 0x1C` (fixed for `CTRL_JD` in 8d73fae, #14) - `0x37` appears to be a newer controller revision of the same panel. Same symptom class as the still-open #26 (EL016F3WRA, `ctrltype 0x0C`) - Solum keeps issuing new controller revisions for existing panels that the firmware doesn't yet know about.
- Fix: add `0x37` to the existing `CTRL_JD` fallthrough case group next to `0x1C`. No other cases/branches touched. The `STYPE_SIZE_16_BWRY_HIGHRES` override further down in the same function was checked and needs no change.

## Test plan
- [x] Built via the documented Docker toolchain (`build_all.sh`) with no new warnings/errors from this change.
- [x] Flashed the resulting `SOLUM_AUTODETECT_FULL.s37` onto the affected physical EL016F5C4C tag via SWD/OpenOCD (`Verified OK`).
- [x] Confirmed the tag now boots past display init, connects to an AP and checks in (previously silent/asleep with the unmodified firmware).
- [x] Repeated the flash + boot verification on two more EL016F5C4C units with the same `ctrltype 0x37`, same result.
